### PR TITLE
feat(application): add default root path

### DIFF
--- a/packages/framework/__tests__/features/current/app/test.ts
+++ b/packages/framework/__tests__/features/current/app/test.ts
@@ -1,0 +1,9 @@
+import { Controller, http, route } from '../../../../src';
+
+@route('/features/current')
+export class App extends Controller {
+  @http.get()
+  index() {
+    return 'hello current';
+  }
+}

--- a/packages/framework/__tests__/features/current/current.spec.ts
+++ b/packages/framework/__tests__/features/current/current.spec.ts
@@ -1,0 +1,14 @@
+import request from 'supertest';
+import { Application } from '../../../src';
+
+const app = new Application();
+
+
+beforeAll(() => app.run(7676));
+afterAll(() => app.close());
+
+
+it('should work base', async (done) => {
+  await request(app._server).get('/features/current').expect(200, 'hello current');
+  done();
+});

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -78,6 +78,7 @@
     "pluralize": "8.0.0",
     "redis": "3.0.2",
     "reflect-metadata": "0.1.13",
+    "require-main-filename": "^2.0.0",
     "statuses": "1.5.0",
     "string-hash": "1.1.3",
     "type-is": "1.6.16",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -78,7 +78,7 @@
     "pluralize": "8.0.0",
     "redis": "3.0.2",
     "reflect-metadata": "0.1.13",
-    "require-main-filename": "^2.0.0",
+    "require-main-filename": "2.0.0",
     "statuses": "1.5.0",
     "string-hash": "1.1.3",
     "type-is": "1.6.16",

--- a/packages/framework/src/foundation/application.ts
+++ b/packages/framework/src/foundation/application.ts
@@ -19,6 +19,7 @@ import { Logger } from '../logger';
 import { Provider } from '../provider';
 import { AppProvider, CommonProvider } from './auto-providers';
 import { HttpServer } from './http-server';
+import mainFilename from 'require-main-filename';
 
 const DEFAULT_PORT = 8080;
 
@@ -116,7 +117,7 @@ export class Application extends Container {
     super();
 
     if (!rootPath) {
-      const _filename = require.main?.filename;
+      const _filename = mainFilename();
       if (_filename) {
         this.rootPath = path.dirname(_filename);
       } else {

--- a/packages/framework/src/foundation/application.ts
+++ b/packages/framework/src/foundation/application.ts
@@ -112,12 +112,20 @@ export class Application extends Container {
    */
   launchCalls: ((...args: any[]) => any)[] = [];
 
-  constructor(rootPath: string, paths: ApplicationPathsOptions = {}) {
+  constructor(rootPath?: string, paths: ApplicationPathsOptions = {}) {
     super();
-    if (!rootPath) throw new Error('must pass the runPath parameter when you apply the instantiation!');
 
-    this.rootPath = rootPath;
-
+    if (!rootPath) {
+      const _filename = require.main?.filename;
+      if (_filename) {
+        this.rootPath = path.dirname(_filename);
+      } else {
+        throw new Error('can not find rootPath in application, may need to pass rootPath in parameters');
+      }
+    } else {
+      this.rootPath = rootPath;
+    }
+    
     this.setPaths(paths);
 
     this.initialContainer();

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -22,3 +22,5 @@ export * from './loader';
 export * from './response';
 export * from './response/redirect';
 export { TMiddlewareStage, TNext } from './middleware';
+
+

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -22,5 +22,3 @@ export * from './loader';
 export * from './response';
 export * from './response/redirect';
 export { TMiddlewareStage, TNext } from './middleware';
-
-

--- a/packages/framework/vendors.d.ts
+++ b/packages/framework/vendors.d.ts
@@ -1,23 +1,28 @@
 
 
 declare module 'keygrip' {
-  var x: any;
+  const x: any;
+  export = x;
+}
+
+declare module 'require-main-filename' {
+  const x: any;
   export = x;
 }
 
 declare module 'core-util-is' {
-  var x: any;
+  const x: any;
   export = x;
 }
 
 
 declare module 'cache-content-type' {
-  var x: any;
+  const x: any;
   export = x;
 }
 
 declare module '@dazejs/trace-page' {
-  var x: any;
+  const x: any;
   export = x;
 }
 


### PR DESCRIPTION
添加了默认根路径

移除了 application 构造函数必须传入 __dirname 参数，变为可选参数，默认从 require.main 中拿

```ts
import { Application } from '@dazejs/framework';

// 移除了必须传入 __dirname 参数，变为可选参数
const app = new Application();

app.run();
```